### PR TITLE
Add post menu on ListActivity, and ignoring post support

### DIFF
--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -82,6 +82,7 @@ import com.hippo.nimingban.dao.ACForumRaw;
 import com.hippo.nimingban.util.Crash;
 import com.hippo.nimingban.util.DB;
 import com.hippo.nimingban.util.LinkMovementMethod2;
+import com.hippo.nimingban.util.PostIgnoreUtils;
 import com.hippo.nimingban.util.ReadableTime;
 import com.hippo.nimingban.util.Settings;
 import com.hippo.nimingban.widget.ContentLayout;
@@ -429,7 +430,7 @@ public final class ListActivity extends AbsActivity
                                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialogInterface, int i) {
-                                        Settings.putIgnoredPosts(post.getNMBPostId());
+                                        PostIgnoreUtils.INSTANCE.putIgnoredPost(post.getNMBPostId());
                                         mPostHelper.removeAt(position);
                                     }
                                 })
@@ -1303,7 +1304,7 @@ public final class ListActivity extends AbsActivity
                     Iterator<Post> postIterator = result.iterator();
                     while (postIterator.hasNext()) {
                         Post post = postIterator.next();
-                        if (Settings.checkPostIgnored(post.getNMBPostId()))
+                        if (PostIgnoreUtils.INSTANCE.checkPostIgnored(post.getNMBPostId()))
                             postIterator.remove();
                     }
 

--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -272,41 +272,7 @@ public final class ListActivity extends AbsActivity
         mRecyclerView.setOnItemLongClickListener(new EasyRecyclerView.OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(EasyRecyclerView parent, View view, int position, long id) {
-                // showDialog start
-                final Post post = mPostHelper.getDataAt(position);
-
-                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialogInterface, int i) {
-                        switch (i) {
-                            case 0:
-                                Intent intent = new Intent(ListActivity.this, TypeSendActivity.class);
-                                intent.setAction(TypeSendActivity.ACTION_CREATE_POST);
-                                intent.putExtra(TypeSendActivity.KEY_SITE, mCurrentForum.getNMBSite().getId());
-                                intent.putExtra(TypeSendActivity.KEY_ID, ACSite.getInstance().getReportForumId());
-                                intent.putExtra(TypeSendActivity.KEY_TEXT, ">>No." + post.getNMBPostId() + "\n");
-                                startActivity(intent);
-                                break;
-                            case 1:
-                                new AlertDialog.Builder(ListActivity.this)
-                                        .setTitle(R.string.ignore_post_confirm_title)
-                                        .setMessage(R.string.ignore_post_confirm_message)
-                                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(DialogInterface dialogInterface, int i) {
-                                                Settings.putIgnoredPosts(post.getNMBPostId());
-                                                mPostHelper.refresh(); // FIXME: May have more prefect resolution.
-                                            }
-                                        })
-                                        .setNegativeButton(android.R.string.no, null)
-                                        .show();
-                                break;
-                        }
-                    }
-                };
-
-                new AlertDialog.Builder(ListActivity.this).setItems(R.array.post_dialog, listener).show();
-                // showDialog end
+                showIgnorePostDialog(position);
                 return true;
             }
         });
@@ -439,6 +405,43 @@ public final class ListActivity extends AbsActivity
                 iterator.remove();
             }
         }
+    }
+
+    private void showIgnorePostDialog(final int position) {
+        final Post post = mPostHelper.getDataAt(position);
+
+        DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                switch (i) {
+                    case 0:
+                        Intent intent = new Intent(ListActivity.this, TypeSendActivity.class);
+                        intent.setAction(TypeSendActivity.ACTION_CREATE_POST);
+                        intent.putExtra(TypeSendActivity.KEY_SITE, mCurrentForum.getNMBSite().getId());
+                        intent.putExtra(TypeSendActivity.KEY_ID, mCurrentForum.getNMBSite().getReportForumId());
+                        intent.putExtra(TypeSendActivity.KEY_TEXT, ">>No." + post.getNMBPostId() + "\n");
+                        startActivity(intent);
+                        break;
+                    case 1:
+                        new AlertDialog.Builder(ListActivity.this)
+                                .setTitle(R.string.ignore_post_confirm_title)
+                                .setMessage(R.string.ignore_post_confirm_message)
+                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialogInterface, int i) {
+                                        Settings.putIgnoredPosts(post.getNMBPostId());
+                                        mPostHelper.removeAt(position);
+                                    }
+                                })
+                                .setNegativeButton(android.R.string.no, null)
+                                .show();
+                        break;
+                }
+            }
+        };
+
+        new AlertDialog.Builder(ListActivity.this)
+                .setTitle("No." + post.getNMBPostId()).setItems(R.array.post_dialog, listener).show();
     }
 
     @Override

--- a/app/src/main/java/com/hippo/nimingban/ui/SettingsActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/SettingsActivity.java
@@ -68,6 +68,7 @@ import com.hippo.nimingban.service.DaDiaoService;
 import com.hippo.nimingban.util.CountDownTimerEx;
 import com.hippo.nimingban.util.LinkMovementMethod2;
 import com.hippo.nimingban.util.OpenUrlHelper;
+import com.hippo.nimingban.util.PostIgnoreUtils;
 import com.hippo.nimingban.util.ReadableTime;
 import com.hippo.nimingban.util.Settings;
 import com.hippo.nimingban.widget.FontTextView;
@@ -982,7 +983,7 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
                 }
             } else if (KEY_RESTORE_IGNORED_POSTS.equals(key)) {
                 // TODO: Need dialog?
-                Settings.resetIgnoredPosts();
+                PostIgnoreUtils.INSTANCE.resetIgnoredPosts();
                 Toast.makeText(getActivity(), R.string.main_restore_ignored_post_successfully, Toast.LENGTH_SHORT).show();
             } else if (KEY_ABOUT_ANALYSIS.equals(key)) {
                 try {

--- a/app/src/main/java/com/hippo/nimingban/ui/SettingsActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/SettingsActivity.java
@@ -440,6 +440,7 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
         private static final String KEY_SAVE_COOKIES = "save_cookies";
         private static final String KEY_RESTORE_COOKIES = "restore_cookies";
         private static final String KEY_APP_ICON = "app_icon";
+        private static final String KEY_RESTORE_IGNORED_POSTS = "restore_ignored_posts";
         private static final String KEY_ABOUT_ANALYSIS = "about_analysis";
 
         private Preference mACCookies;
@@ -450,6 +451,7 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
         private Preference mImageSaveLocation;
         private Preference mChaosLevel;
         private IconListPreference mAppIcon;
+        private Preference mRestoreIgnoredPosts;
         private Preference mAboutAnalysis;
 
         private long mMaxAgeDiff = 0;
@@ -496,6 +498,7 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
             mImageSaveLocation = findPreference(Settings.KEY_IMAGE_SAVE_LOACTION);
             mChaosLevel = findPreference(Settings.KEY_CHAOS_LEVEL);
             mAppIcon = (IconListPreference) findPreference(KEY_APP_ICON);
+            mRestoreIgnoredPosts = findPreference(KEY_RESTORE_IGNORED_POSTS);
             mAboutAnalysis = findPreference(KEY_ABOUT_ANALYSIS);
 
             mACCookies.setOnPreferenceClickListener(this);
@@ -504,6 +507,7 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
             mRestoreCookies.setOnPreferenceClickListener(this);
             mFeedId.setOnPreferenceClickListener(this);
             mImageSaveLocation.setOnPreferenceClickListener(this);
+            mRestoreIgnoredPosts.setOnPreferenceClickListener(this);
             mAboutAnalysis.setOnPreferenceClickListener(this);
 
             mChaosLevel.setOnPreferenceChangeListener(this);
@@ -976,6 +980,10 @@ public class SettingsActivity extends AbsPreferenceActivity implements ActivityC
                 } else {
                     showDirPickerDialogL();
                 }
+            } else if (KEY_RESTORE_IGNORED_POSTS.equals(key)) {
+                // TODO: Need dialog?
+                Settings.resetIgnoredPosts();
+                Toast.makeText(getActivity(), R.string.main_restore_ignored_post_successfully, Toast.LENGTH_SHORT).show();
             } else if (KEY_ABOUT_ANALYSIS.equals(key)) {
                 try {
                     CharSequence message = Html.fromHtml(IOUtils.readString(

--- a/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
+++ b/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
@@ -1,0 +1,82 @@
+package com.hippo.nimingban.util;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+public class PostIgnoreUtils {
+
+    public static final PostIgnoreUtils INSTANCE = new PostIgnoreUtils();
+
+    public static final String KEY_IGNORED_POSTS = "ignored_posts";
+
+    private LinkedHashMap<String, Object> mHashMap;
+
+    private PostIgnoreUtils() {
+        mHashMap = loadFromSettings();
+    }
+
+    public void putIgnoredPost(String id) {
+        mHashMap.put(id, null);
+        writeToSettings();
+    }
+
+    public void resetIgnoredPosts() {
+        mHashMap.clear();
+        writeToSettings();
+    }
+
+    public boolean checkPostIgnored(String id) {
+        Iterator<String> iterator = mHashMap.keySet().iterator();
+        boolean flag = false;
+
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            if (key.equals(id)) {
+                flag = true;
+                break;
+            }
+        }
+
+        return flag;
+    }
+
+    private void writeToSettings() {
+        JSONArray arr = new JSONArray(mHashMap.keySet());
+        Settings.putString(KEY_IGNORED_POSTS, arr.toString());
+    }
+
+    private PostIgnoreMap loadFromSettings() {
+        PostIgnoreMap map = new PostIgnoreMap();
+
+        try {
+            JSONArray arr = new JSONArray(Settings.getString(KEY_IGNORED_POSTS, "[]"));
+            for (int i = 0; i < arr.length(); ++i)
+                map.put(arr.getString(i), null);
+        } catch (JSONException e) {
+            // TODO: Error handling
+        }
+
+        return map;
+    }
+
+    private final class PostIgnoreMap extends LinkedHashMap<String, Object> {
+        private final int maxItems;
+
+        public PostIgnoreMap() {
+            this(100);
+        }
+
+        private PostIgnoreMap(int maxItems) {
+            super(16, 0.75f, true);
+            this.maxItems = maxItems;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Entry<String, Object> eldest) {
+            return this.size() > this.maxItems;
+        }
+    }
+}

--- a/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
+++ b/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
@@ -34,9 +34,9 @@ public class PostIgnoreUtils {
 
         while (iterator.hasNext()) {
             String key = iterator.next();
-            mHashMap.get(key);
             if (key.equals(id)) {
                 flag = true;
+                mHashMap.get(key);
                 break;
             }
         }

--- a/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
+++ b/app/src/main/java/com/hippo/nimingban/util/PostIgnoreUtils.java
@@ -34,6 +34,7 @@ public class PostIgnoreUtils {
 
         while (iterator.hasNext()) {
             String key = iterator.next();
+            mHashMap.get(key);
             if (key.equals(id)) {
                 flag = true;
                 break;

--- a/app/src/main/java/com/hippo/nimingban/util/Settings.java
+++ b/app/src/main/java/com/hippo/nimingban/util/Settings.java
@@ -463,31 +463,6 @@ public final class Settings {
         sSettingsPre.edit().putString(KEY_CRASH_FILENAME, value).commit();
     }
 
-    public static final String KEY_IGNORED_POSTS = "ignored_posts";
-    public static final Set<String> DEFAULT_IGNORED_POSTS = new HashSet<>();
-
-    public static Set<String> getIgnoredPosts() {
-        return getStringSet(KEY_IGNORED_POSTS, DEFAULT_IGNORED_POSTS);
-    }
-
-    public static void putIgnoredPosts(String id) {
-        if (checkPostIgnored(id)) // To prevent unexpected bug
-            return;
-
-        Set<String> set = getIgnoredPosts();
-        set.add(id);
-        putStringSet(KEY_IGNORED_POSTS, set);
-    }
-
-    public static boolean checkPostIgnored(String id) {
-        Set<String> set = getIgnoredPosts();
-        return set.contains(id);
-    }
-
-    public static void resetIgnoredPosts() {
-        putStringSet(KEY_IGNORED_POSTS, DEFAULT_IGNORED_POSTS);
-    }
-
     /**
      * http://stackoverflow.com/questions/332079
      *

--- a/app/src/main/java/com/hippo/nimingban/util/Settings.java
+++ b/app/src/main/java/com/hippo/nimingban/util/Settings.java
@@ -26,6 +26,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
+import android.util.ArraySet;
 
 import com.hippo.nimingban.NMBAppConfig;
 import com.hippo.unifile.UniFile;
@@ -40,6 +41,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.HashSet;
+import java.util.Set;
 
 public final class Settings {
 
@@ -92,6 +95,15 @@ public final class Settings {
 
     public static void putString(String key, String value) {
         sSettingsPre.edit().putString(key, value).apply();
+    }
+
+    public static Set<String> getStringSet(String key, Set<String> defValue) {
+        return sSettingsPre.getStringSet(key, defValue);
+    }
+
+    public static void putStringSet(String key, Set<String> value) {
+        sSettingsPre.edit().remove(key).apply(); // See: https://bon-app-etit.blogspot.com/2013/08/android-bug-stringset-in.html
+        sSettingsPre.edit().putStringSet(key, value).apply();
     }
 
     public static int getIntFromStr(String key, int defValue) {
@@ -449,6 +461,31 @@ public final class Settings {
     @SuppressLint("CommitPrefEdits")
     public static void putCrashFilename(String value) {
         sSettingsPre.edit().putString(KEY_CRASH_FILENAME, value).commit();
+    }
+
+    public static final String KEY_IGNORED_POSTS = "ignored_posts";
+    public static final Set<String> DEFAULT_IGNORED_POSTS = new HashSet<>();
+
+    public static Set<String> getIgnoredPosts() {
+        return getStringSet(KEY_IGNORED_POSTS, DEFAULT_IGNORED_POSTS);
+    }
+
+    public static void putIgnoredPosts(String id) {
+        if (checkPostIgnored(id)) // To prevent unexpected bug
+            return;
+
+        Set<String> set = getIgnoredPosts();
+        set.add(id);
+        putStringSet(KEY_IGNORED_POSTS, set);
+    }
+
+    public static boolean checkPostIgnored(String id) {
+        Set<String> set = getIgnoredPosts();
+        return set.contains(id);
+    }
+
+    public static void resetIgnoredPosts() {
+        putStringSet(KEY_IGNORED_POSTS, DEFAULT_IGNORED_POSTS);
     }
 
     /**

--- a/app/src/main/java/com/hippo/nimingban/widget/ContentLayout.java
+++ b/app/src/main/java/com/hippo/nimingban/widget/ContentLayout.java
@@ -33,6 +33,8 @@ import com.hippo.easyrecyclerview.HandlerDrawable;
 import com.hippo.easyrecyclerview.LayoutManagerUtils;
 import com.hippo.effect.ViewTransition;
 import com.hippo.nimingban.R;
+import com.hippo.nimingban.client.ac.data.ACPost;
+import com.hippo.nimingban.client.data.Post;
 import com.hippo.refreshlayout.RefreshLayout;
 import com.hippo.util.ExceptionUtils;
 import com.hippo.widget.ProgressView;

--- a/app/src/main/java/com/hippo/nimingban/widget/ContentLayout.java
+++ b/app/src/main/java/com/hippo/nimingban/widget/ContentLayout.java
@@ -33,8 +33,6 @@ import com.hippo.easyrecyclerview.HandlerDrawable;
 import com.hippo.easyrecyclerview.LayoutManagerUtils;
 import com.hippo.effect.ViewTransition;
 import com.hippo.nimingban.R;
-import com.hippo.nimingban.client.ac.data.ACPost;
-import com.hippo.nimingban.client.data.Post;
 import com.hippo.refreshlayout.RefreshLayout;
 import com.hippo.util.ExceptionUtils;
 import com.hippo.widget.ProgressView;

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -102,7 +102,7 @@
 
     <string name="ignore_post">永久屏蔽此串</string>
 
-    <string name="ignore_post_confirm_title">你确定要永久屏蔽此串吗？</string>
+    <string name="ignore_post_confirm_title">你确定要屏蔽此串吗？</string>
     <string name="ignore_post_confirm_message">今后你只能通过输入此串串号进入</string>
 
     <string name="comment_copied_clipboard">评论文字已复制到剪贴板</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -100,6 +100,11 @@
     <string name="text_to_image">生成文字图片</string>
     <string name="take_photo">拍个照</string>
 
+    <string name="ignore_post">永久屏蔽此串</string>
+
+    <string name="ignore_post_confirm_title">你确定要永久屏蔽此串吗？</string>
+    <string name="ignore_post_confirm_message">今后你只能通过输入此串串号进入</string>
+
     <string name="comment_copied_clipboard">评论文字已复制到剪贴板</string>
 
     <string name="cant_get_the_reference">无法找到引用</string>
@@ -261,6 +266,9 @@
     <string name="main_fix_image_urls">修正图片链接</string>
     <string name="main_fix_image_urls_summary_on">使用默认图片链接</string>
     <string name="main_fix_image_urls_summary_off">通过 API 获取图片链接。若图片加载失败，请启用该项。</string>
+    <string name="main_restore_ignored_post">恢复所有已屏蔽的串</string>
+    <string name="main_restore_ignored_post_summary">你之前所屏蔽的串将会重新出现</string>
+    <string name="main_restore_ignored_post_successfully">已恢复所有被屏蔽的串</string>
     <string name="main_analysis">启用数据统计</string>
     <string name="main_about_analysis">关于数据统计</string>
     <string name="main_author">作者</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -30,6 +30,11 @@
         <item>@string/take_photo</item>
     </string-array>
 
+    <string-array name="post_dialog">
+        <item>@string/report</item>
+        <item>@string/ignore_post</item>
+    </string-array>
+
     <string-array name="image_loading_strategy_entries">
         <item>@string/image_loading_strategy_all</item>
         <item>@string/image_loading_strategy_wifi</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,11 @@
     <string name="text_to_image">Text to image</string>
     <string name="take_photo">Take a photo</string>
 
+    <string name="ignore_post">Ignore this post</string>
+
+    <string name="ignore_post_confirm_title">Are you sure want to ignore this post?</string>
+    <string name="ignore_post_confirm_message">After ignored, you can access it from enter post id only.</string>
+
     <string name="comment_copied_clipboard">Copied to clipboard</string>
 
     <string name="cant_get_the_reference">Can\'t get the reference</string>
@@ -268,6 +273,9 @@
     <string name="main_fix_image_urls">Fix image URLs</string>
     <string name="main_fix_image_urls_summary_on">Use default image URLs</string>
     <string name="main_fix_image_urls_summary_off">Get image URLs from the API. Enable it if loading images failed</string>
+    <string name="main_restore_ignored_post">Restore all ignored posts</string>
+    <string name="main_restore_ignored_post_summary">The posts you ignored will redisplayed</string>
+    <string name="main_restore_ignored_post_success">Restoring successful</string>
     <string name="main_analysis">Enable data analysis</string>
     <string name="main_about_analysis">About data analysis</string>
     <string name="main_author">Author</string>

--- a/app/src/main/res/xml/config_settings.xml
+++ b/app/src/main/res/xml/config_settings.xml
@@ -83,6 +83,11 @@
         android:defaultValue="0"
         android:widgetLayout="@layout/preference_widget_icon_list"/>
 
+    <Preference
+        android:key="restore_ignored_posts"
+        android:title="@string/main_restore_ignored_post"
+        android:summary="@string/main_restore_ignored_post_summary"/>
+
     <com.hippo.preference.FixedSwitchPreference
         style="?android:attr/preferenceStyle"
         android:key="analysis"


### PR DESCRIPTION
在ListActivity的串中加上個菜單，可以不用點開串直接進行舉報操作，另外還可以永久屏蔽某個串，就像蘆葦島一樣

...不過我有個疑問，似乎用ContextMenu來做菜單會比彈出一個Dialog要更好些，但是我在嘗試給它加上菜單時，雖然菜單可以正常彈出，但是點擊事件的註冊似乎只會對縮略圖生效，點擊整個串並不會進入到詳情介面。不知道有什麼比較好的方法可以解決這個問題？