### PR TITLE
More small features: strict post ignore mode, enchanced jump page dialog, etc.

### DIFF
--- a/app/src/main/java/com/hippo/app/CheckBoxDialogBuilder.java
+++ b/app/src/main/java/com/hippo/app/CheckBoxDialogBuilder.java
@@ -28,18 +28,25 @@ import com.hippo.nimingban.R;
 
 public class CheckBoxDialogBuilder extends AlertDialog.Builder {
 
+    private final boolean mShowCheckbox;
     private final CheckBox mCheckBox;
 
     @SuppressLint("InflateParams")
-    public CheckBoxDialogBuilder(Context context, CharSequence message, String checkText, boolean checked) {
+    public CheckBoxDialogBuilder(Context context, CharSequence message, String checkText, boolean showCheckbox, boolean checked) {
         super(context);
         View view = LayoutInflater.from(context).inflate(R.layout.dialog_checkbox_builder, null);
         setView(view);
         TextView messageView = (TextView) view.findViewById(R.id.message);
+        mShowCheckbox = showCheckbox;
         mCheckBox = (CheckBox) view.findViewById(R.id.checkbox);
         messageView.setText(message);
         mCheckBox.setText(checkText);
         mCheckBox.setChecked(checked);
+        if (!showCheckbox) mCheckBox.setVisibility(View.GONE);
+    }
+
+    public boolean isShowCheckbox() {
+        return mShowCheckbox;
     }
 
     public boolean isChecked() {

--- a/app/src/main/java/com/hippo/nimingban/ui/DoodleActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/DoodleActivity.java
@@ -288,6 +288,8 @@ public final class DoodleActivity extends TranslucentActivity implements View.On
         public void onClick(DialogInterface dialog, int which) {
             if (DialogInterface.BUTTON_POSITIVE == which) {
                 mDoodleView.setPaintColor(mView.getColor());
+            } else if (DialogInterface.BUTTON_NEUTRAL == which) {
+                mDoodleView.setPaintColor(ResourcesUtils.getAttrColor(DoodleActivity.this, R.attr.colorPureInverse));
             }
         }
     }
@@ -298,6 +300,7 @@ public final class DoodleActivity extends TranslucentActivity implements View.On
                 .setView(helper.getView())
                 .setPositiveButton(android.R.string.ok, helper)
                 .setNegativeButton(android.R.string.cancel, null)
+                .setNeutralButton(R.string.doodle_reset_color, helper)
                 .show();
     }
 

--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -143,6 +143,7 @@ public final class ListActivity extends AbsActivity
     private ActionBarDrawerToggle mDrawerToggle;
 
     private MenuItem mRule;
+    private MenuItem mNotice;
     private MenuItem mCreatePost;
     private MenuItem mSortForumsMenu;
 
@@ -230,6 +231,7 @@ public final class ListActivity extends AbsActivity
                 }
                 if (mRightDrawer == view) {
                     setMenuItemVisible(mRule, true);
+                    setMenuItemVisible(mNotice, true);
                     setMenuItemVisible(mCreatePost, true);
                     setMenuItemVisible(mSortForumsMenu, false);
                 }
@@ -242,6 +244,7 @@ public final class ListActivity extends AbsActivity
                 }
                 if (mRightDrawer == view) {
                     setMenuItemVisible(mRule, false);
+                    setMenuItemVisible(mNotice, false);
                     setMenuItemVisible(mCreatePost, false);
                     setMenuItemVisible(mSortForumsMenu, true);
                 }
@@ -638,7 +641,11 @@ public final class ListActivity extends AbsActivity
         mNMBClient.execute(request);
 
         // Get Notice
-        request = new NMBRequest();
+        getNotice(false);
+    }
+
+    private void getNotice(final boolean forceDisplay) {
+        NMBRequest request = new NMBRequest();
         mNoticeRequest = request;
         request.setSite(ACSite.getInstance());
         request.setMethod(NMBClient.METHOD_NOTICE);
@@ -655,17 +662,17 @@ public final class ListActivity extends AbsActivity
                 }
                 long oldDate = Settings.getNoticeDate();
                 final long newDate = result.date;
-                if (newDate <= oldDate) {
+                if (newDate <= oldDate && !forceDisplay) {
                     return;
                 }
 
                 final CheckBoxDialogBuilder builder = new CheckBoxDialogBuilder(
-                        ListActivity.this, Html.fromHtml(result.content), getString(R.string.get_it), false);
+                        ListActivity.this, Html.fromHtml(result.content), getString(R.string.get_it), !forceDisplay, false);
                 Dialog dialog = builder.setTitle(R.string.notice).setOnDismissListener(
                         new DialogInterface.OnDismissListener() {
                             @Override
                             public void onDismiss(DialogInterface dialog) {
-                                if (builder.isChecked()) {
+                                if (builder.isShowCheckbox() && builder.isChecked()) {
                                     Settings.putNoticeDate(newDate);
                                 }
                             }
@@ -796,15 +803,18 @@ public final class ListActivity extends AbsActivity
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.activity_list, menu);
         mRule = menu.findItem(R.id.action_rule);
+        mNotice = menu.findItem(R.id.action_notice);
         mCreatePost = menu.findItem(R.id.action_create_post);
         mSortForumsMenu = menu.findItem(R.id.action_sort_forums);
 
         if (mDrawerLayout.isDrawerOpen(Gravity.RIGHT)) {
             mRule.setVisible(false);
+            mNotice.setVisible(false);
             mCreatePost.setVisible(false);
             mSortForumsMenu.setVisible(true);
         } else {
             mRule.setVisible(true);
+            mNotice.setVisible(true);
             mCreatePost.setVisible(true);
             mSortForumsMenu.setVisible(false);
         }
@@ -874,6 +884,10 @@ public final class ListActivity extends AbsActivity
                     tv.setMovementMethod(new LinkMovementMethod2(ListActivity.this));
                     new AlertDialog.Builder(this).setTitle(R.string.rule).setView(view).show();
                 }
+                return true;
+            case R.id.action_notice:
+                if (mCurrentForum != null)
+                    getNotice(true);
                 return true;
             case R.id.action_create_post:
                 if (mCurrentForum != null) {

--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -1021,6 +1021,10 @@ public final class ListActivity extends AbsActivity
                 startActivity(intent);
                 mDialog.dismiss();
             } else if (mNeutral == v) {
+                if (!TextUtils.isDigitsOnly(keyword)) {
+                    Toast.makeText(ListActivity.this, R.string.invalid_post_id, Toast.LENGTH_SHORT).show();
+                    return;
+                }
                 Intent intent = new Intent(ListActivity.this, PostActivity.class);
                 intent.setAction(PostActivity.ACTION_SITE_REPLY_ID);
                 intent.putExtra(PostActivity.KEY_SITE, ACSite.getInstance().getId());

--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -424,7 +424,7 @@ public final class ListActivity extends AbsActivity
                 switch (i) {
                     case 0:
                         Intent intent = new Intent(ListActivity.this, TypeSendActivity.class);
-                        intent.setAction(TypeSendActivity.ACTION_CREATE_POST);
+                        intent.setAction(TypeSendActivity.ACTION_REPORT);
                         intent.putExtra(TypeSendActivity.KEY_SITE, mCurrentForum.getNMBSite().getId());
                         intent.putExtra(TypeSendActivity.KEY_ID, mCurrentForum.getNMBSite().getReportForumId());
                         intent.putExtra(TypeSendActivity.KEY_TEXT, ">>No." + post.getNMBPostId() + "\n");
@@ -433,7 +433,7 @@ public final class ListActivity extends AbsActivity
                     case 1:
                         new AlertDialog.Builder(ListActivity.this)
                                 .setTitle(R.string.ignore_post_confirm_title)
-                                .setMessage(R.string.ignore_post_confirm_message)
+                                .setMessage(Settings.getEnableStrictIgnoreMode() ? R.string.ignore_post_confirm_message_strict : R.string.ignore_post_confirm_message)
                                 .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
                                     @Override
                                     public void onClick(DialogInterface dialogInterface, int i) {

--- a/app/src/main/java/com/hippo/nimingban/ui/SearchActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/SearchActivity.java
@@ -38,6 +38,7 @@ import com.hippo.nimingban.client.NMBClient;
 import com.hippo.nimingban.client.NMBRequest;
 import com.hippo.nimingban.client.ac.data.ACSearchItem;
 import com.hippo.nimingban.client.data.ACSite;
+import com.hippo.nimingban.util.PostIgnoreUtils;
 import com.hippo.nimingban.util.ReadableTime;
 import com.hippo.nimingban.util.Settings;
 import com.hippo.nimingban.widget.ContentLayout;
@@ -435,6 +436,13 @@ public class SearchActivity extends TranslucentActivity implements EasyRecyclerV
                 mSearchHelper.onGetEmptyData(mTaskId);
                 mSearchHelper.setPages(mPage);
             } else {
+                Iterator<ACSearchItem> itemIterator = result.iterator();
+                while (itemIterator.hasNext()) {
+                    ACSearchItem item = itemIterator.next();
+                    if (PostIgnoreUtils.INSTANCE.checkPostIgnored(item.getNMBPostId()))
+                        itemIterator.remove();
+                }
+
                 mSearchHelper.onGetPageData(mTaskId, result);
                 mSearchHelper.setPages(Integer.MAX_VALUE);
             }

--- a/app/src/main/java/com/hippo/nimingban/ui/fragment/PostFragment.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/fragment/PostFragment.java
@@ -71,6 +71,7 @@ import com.hippo.nimingban.ui.GalleryActivity2;
 import com.hippo.nimingban.ui.PostActivity;
 import com.hippo.nimingban.util.MinMaxFilter;
 import com.hippo.nimingban.util.OpenUrlHelper;
+import com.hippo.nimingban.util.PostIgnoreUtils;
 import com.hippo.nimingban.util.ReadableTime;
 import com.hippo.nimingban.util.Settings;
 import com.hippo.nimingban.widget.ContentLayout;
@@ -148,6 +149,8 @@ public class PostFragment extends BaseFragment
     private List<WeakReference<ReplyHolder>> mHolderList = new LinkedList<>();
 
     private Callback mCallback;
+
+    private boolean isLoaded;
 
     public void setCallback(Callback callback) {
         mCallback = callback;
@@ -275,6 +278,8 @@ public class PostFragment extends BaseFragment
         Messenger.getInstance().register(Constants.MESSENGER_ID_REPLY, this);
         Messenger.getInstance().register(Constants.MESSENGER_ID_FAST_SCROLLER, this);
 
+        isLoaded = false;
+
         return view;
     }
 
@@ -365,6 +370,8 @@ public class PostFragment extends BaseFragment
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
+        if (!isLoaded) return true;
+
         switch (item.getItemId()) {
             case R.id.action_go_to:
                 int pages = mReplyHelper.getPages();
@@ -650,6 +657,18 @@ public class PostFragment extends BaseFragment
                         startActivity(intent);
                     }
                 });
+            }
+
+            // FIXME: Need getting rid of unwanted requests (example: post image thumbnail)
+            if (Settings.getEnableStrictIgnoreMode() && PostIgnoreUtils.INSTANCE.checkPostIgnored(postId)) {
+                mLeftText.setText("");
+                mCenterText.setText("No.9999999");
+                mRightText.setText(R.string.from_the_future);
+                mThumb.setVisibility(View.GONE);
+                mThumb.unload();
+                mContent.setText(R.string.ignore_post_message);
+                mButton.setVisibility(View.GONE);
+                mButton.setOnClickListener(null);
             }
 
             mRequest = null;
@@ -980,6 +999,12 @@ public class PostFragment extends BaseFragment
                 request.setCallback(new GetPostIdFromReferenceListener());
                 mNMBClient.execute(request);
             } else {
+                if (Settings.getEnableStrictIgnoreMode() && PostIgnoreUtils.INSTANCE.checkPostIgnored(mId)) {
+                    isLoaded = false;
+                    mReplyHelper.showText(getString(R.string.ignore_post_message));
+                    return;
+                }
+
                 NMBRequest request = new NMBRequest();
                 mNMBRequest = request;
                 request.setSite(mSite);
@@ -995,6 +1020,12 @@ public class PostFragment extends BaseFragment
 
         @Override
         public void onSuccess(ACReference result) {
+            if (Settings.getEnableStrictIgnoreMode() && PostIgnoreUtils.INSTANCE.checkPostIgnored(result.postId)) {
+                isLoaded = false;
+                mReplyHelper.showText(getString(R.string.ignore_post_message));
+                return;
+            }
+
             mReplyId = null;
             mId = result.postId;
             mToolbar.setTitle(mSite.getPostTitle(getContext(), mId));
@@ -1079,6 +1110,8 @@ public class PostFragment extends BaseFragment
                         mReplyHelper.setPages(Integer.MAX_VALUE); // Keep going
                     }
                 }
+
+                isLoaded = true;
             }
             // Clear
             mRequest = null;
@@ -1093,6 +1126,8 @@ public class PostFragment extends BaseFragment
                 mNMBRequest = null;
 
                 mReplyHelper.onGetExpection(mTaskId, e);
+
+                isLoaded = false;
             }
             // Clear
             mRequest = null;
@@ -1105,6 +1140,8 @@ public class PostFragment extends BaseFragment
 
                 // Clear
                 mNMBRequest = null;
+
+                isLoaded = false;
             }
             // Clear
             mRequest = null;

--- a/app/src/main/java/com/hippo/nimingban/ui/fragment/PostFragment.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/fragment/PostFragment.java
@@ -32,10 +32,13 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
+import android.text.Editable;
+import android.text.InputFilter;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
 import android.text.TextUtils;
+import android.text.TextWatcher;
 import android.text.style.ClickableSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
@@ -46,6 +49,7 @@ import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -65,6 +69,7 @@ import com.hippo.nimingban.client.data.Reply;
 import com.hippo.nimingban.client.data.Site;
 import com.hippo.nimingban.ui.GalleryActivity2;
 import com.hippo.nimingban.ui.PostActivity;
+import com.hippo.nimingban.util.MinMaxFilter;
 import com.hippo.nimingban.util.OpenUrlHelper;
 import com.hippo.nimingban.util.ReadableTime;
 import com.hippo.nimingban.util.Settings;
@@ -403,12 +408,13 @@ public class PostFragment extends BaseFragment
     }
 
     private class GoToDialogHelper implements View.OnClickListener,
-            DialogInterface.OnDismissListener {
+            DialogInterface.OnDismissListener, Slider.OnSetProgressListener, TextWatcher {
 
         private int mPages;
 
         private View mView;
         private Slider mSlider;
+        private EditText mEditText;
 
         private Dialog mDialog;
 
@@ -421,6 +427,12 @@ public class PostFragment extends BaseFragment
             mSlider = (Slider) mView.findViewById(R.id.slider);
             mSlider.setRange(1, pages);
             mSlider.setProgress(currentPage + 1);
+            mSlider.setOnSetProgressListener(this);
+            mEditText = (EditText) mView.findViewById(R.id.page_input);
+            mEditText.setText(Integer.toString(currentPage + 1)); // Android still treating int as resid
+            mEditText.setHint("1");
+            mEditText.setFilters(new InputFilter[]{new MinMaxFilter(1, pages)});
+            mEditText.addTextChangedListener(this);
         }
 
         public View getView() {
@@ -451,6 +463,30 @@ public class PostFragment extends BaseFragment
         public void onDismiss(DialogInterface dialog) {
             mDialog = null;
         }
+
+        @Override
+        public void onSetProgress(Slider slider, int newProgress, int oldProgress, boolean byUser, boolean confirm) {
+            if (!byUser) return;
+            mEditText.setText(String.valueOf(newProgress)); // To prevent Android treat progress as resid
+        }
+
+        @Override
+        public void onTextChanged(CharSequence s, int start, int before, int count) {
+            int i = s.length() > 0 ? Integer.parseInt(s.toString()) : 1;
+            mSlider.setProgress(i);
+        }
+
+        @Override
+        public void onFingerDown() {}
+
+        @Override
+        public void onFingerUp() {}
+
+        @Override
+        public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+        @Override
+        public void afterTextChanged(Editable s) {}
     }
 
 

--- a/app/src/main/java/com/hippo/nimingban/util/MinMaxFilter.java
+++ b/app/src/main/java/com/hippo/nimingban/util/MinMaxFilter.java
@@ -1,0 +1,34 @@
+package com.hippo.nimingban.util;
+
+import android.text.InputFilter;
+import android.text.Spanned;
+
+// https://stackoverflow.com/q/14212518
+public class MinMaxFilter implements InputFilter {
+
+    private int mMin;
+    private int mMax;
+
+    public MinMaxFilter(int min, int max) {
+        mMin = min;
+        mMax = max;
+    }
+
+    @Override
+    public CharSequence filter(CharSequence source, int start, int end, Spanned dest, int dstart, int dend) {
+        try {
+            // Remove the string out of destination that is to be replaced
+            String newVal = dest.toString().substring(0, dstart) + dest.toString().substring(dend, dest.toString().length());
+            // Add the new string in
+            newVal = newVal.substring(0, dstart) + source.toString() + newVal.substring(dstart, newVal.length());
+            int input = Integer.parseInt(newVal);
+            if (isInRange(mMin, mMax, input))
+                return null;
+        } catch (NumberFormatException nfe) {}
+        return "";
+    }
+
+    private boolean isInRange(int a, int b, int c) {
+        return b > a ? c >= a && c <= b : c >= b && c <= a;
+    }
+}

--- a/app/src/main/java/com/hippo/nimingban/util/Settings.java
+++ b/app/src/main/java/com/hippo/nimingban/util/Settings.java
@@ -488,6 +488,13 @@ public final class Settings {
         putString(KEY_CUSTOMIZED_AC_HOST, value);
     }
 
+    public static final String KEY_STRICT_IGNORE_MODE = "strict_ignore_post_mode";
+    public static final boolean VALUE_STRICT_IGNORE_MODE = false;
+
+    public static boolean getEnableStrictIgnoreMode() {
+        return getBoolean(KEY_STRICT_IGNORE_MODE, VALUE_STRICT_IGNORE_MODE);
+    }
+
     /**
      * http://stackoverflow.com/questions/332079
      *

--- a/app/src/main/res/layout/dialog_go_to.xml
+++ b/app/src/main/res/layout/dialog_go_to.xml
@@ -22,28 +22,43 @@
     android:paddingTop="16dp"
     android:paddingLeft="16dp"
     android:paddingRight="16dp"
-    android:orientation="horizontal">
+    android:orientation="vertical">
 
-    <TextView
-        android:id="@+id/start"
-        android:layout_width="32dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:gravity="center_horizontal"/>
+        android:orientation="horizontal">
 
-    <com.hippo.widget.Slider
-        android:id="@+id/slider"
-        style="@style/Slider"
-        android:layout_width="0dp"
-        android:layout_height="48dp"
-        android:layout_weight="1"
-        android:layout_gravity="center_horizontal"/>
+        <TextView
+            android:id="@+id/start"
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:gravity="center_horizontal"/>
 
-    <TextView
-        android:id="@+id/end"
-        android:layout_width="32dp"
+        <com.hippo.widget.Slider
+            android:id="@+id/slider"
+            style="@style/Slider"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:layout_gravity="center_horizontal"/>
+
+        <TextView
+            android:id="@+id/end"
+            android:layout_width="32dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:gravity="center_horizontal"/>
+
+    </LinearLayout>
+
+    <EditText
+        android:id="@+id/page_input"
+        android:layout_width="48dp"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:gravity="center_horizontal"/>
+        android:layout_gravity="center_horizontal"
+        android:gravity="center_horizontal"
+        android:inputType="number" />
 
 </LinearLayout>

--- a/app/src/main/res/menu/activity_list.xml
+++ b/app/src/main/res/menu/activity_list.xml
@@ -32,6 +32,11 @@
         app:showAsAction="never"/>
 
     <item
+        android:id="@+id/action_notice"
+        android:title="@string/notice"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_sort_forums"
         android:title="@string/sort_forums"
         android:icon="@drawable/v_sort_dark_x24"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -197,6 +197,7 @@
     <string name="type_send_watermark">水印</string>
 
     <string name="doodle">涂鸦</string>
+    <string name="doodle_reset_color">重设</string>
     <string name="save_doodle">保存涂鸦？</string>
     <string name="cant_create_image_file">无法保存图片文件</string>
     <string name="saving">保存中…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -105,6 +105,9 @@
 
     <string name="ignore_post_confirm_title">你确定要屏蔽此串吗？</string>
     <string name="ignore_post_confirm_message">今后你只能通过输入此串串号进入</string>
+    <string name="ignore_post_confirm_message_strict">今后除非你通过设置取消屏蔽所有串，否则将无法再次访问</string>
+
+    <string name="ignore_post_message">此串已被你屏蔽</string>
 
     <string name="comment_copied_clipboard">评论文字已复制到剪贴板</string>
 
@@ -278,6 +281,9 @@
     <string name="main_fix_image_urls">修正图片链接</string>
     <string name="main_fix_image_urls_summary_on">使用默认图片链接</string>
     <string name="main_fix_image_urls_summary_off">通过 API 获取图片链接。若图片加载失败，请启用该项。</string>
+    <string name="main_strict_ignore_post_mode">严格屏蔽模式</string>
+    <string name="main_strict_ignore_post_mode_summary_on">你将无法访问被屏蔽的串</string>
+    <string name="main_strict_ignore_post_mode_summary_off">你仍可通过输入串号的方法访问被屏蔽的串</string>
     <string name="main_restore_ignored_post">恢复所有已屏蔽的串</string>
     <string name="main_restore_ignored_post_summary">你之前所屏蔽的串将会重新出现</string>
     <string name="main_restore_ignored_post_successfully">已恢复所有被屏蔽的串</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">关键字为空</string>
+    <string name="invalid_post_id">不是有效的串号</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜索 - %s</string>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -197,6 +197,7 @@
     <string name="type_send_watermark">水印</string>
 
     <string name="doodle">塗鴉</string>
+    <string name="doodle_reset_color">重設</string>
     <string name="save_doodle">保存塗鴉？</string>
     <string name="cant_create_image_file">無法保存圖片文件</string>
     <string name="saving">保存中…</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -105,6 +105,9 @@
 
     <string name="ignore_post_confirm_title">你確定要屏蔽此串嗎？</string>
     <string name="ignore_post_confirm_message">今後你只能通過輸入此串串號進入</string>
+    <string name="ignore_post_confirm_message_strict">今後除非你通過設置取消屏蔽所有串，否則將無法再次訪問</string>
+
+    <string name="ignore_post_message">此串已被你屏蔽</string>
 
     <string name="comment_copied_clipboard">評論文字已複製到剪貼板</string>
 
@@ -278,6 +281,9 @@
     <string name="main_fix_image_urls">修正圖片鏈接</string>
     <string name="main_fix_image_urls_summary_on">使用默認圖片鏈接</string>
     <string name="main_fix_image_urls_summary_off">通過 API 獲取圖片鏈接。若圖片加載失敗，請啟用該項。</string>
+    <string name="main_strict_ignore_post_mode">嚴格屏蔽模式</string>
+    <string name="main_strict_ignore_post_mode_summary_on">你將無法訪問被屏蔽的串</string>
+    <string name="main_strict_ignore_post_mode_summary_off">你仍可通過輸入串號的方式訪問被屏蔽的串</string>
     <string name="main_restore_ignored_post">恢復所有已屏蔽的串</string>
     <string name="main_restore_ignored_post_summary">你之前所屏蔽的串將會重新出現</string>
     <string name="main_restore_ignored_post_successfully">已恢復所有被屏蔽的串</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">關鍵字為空</string>
+    <string name="invalid_post_id">不是有效的串號</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜索 - %s</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">關鍵字為空</string>
+    <string name="invalid_post_id">不是有效的串號</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜尋 - %s</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -197,6 +197,7 @@
     <string name="type_send_watermark">水印</string>
 
     <string name="doodle">塗鴉</string>
+    <string name="doodle_reset_color">重設</string>
     <string name="save_doodle">儲存塗鴉？</string>
     <string name="cant_create_image_file">無法儲存圖片檔案</string>
     <string name="saving">儲存中…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -105,6 +105,9 @@
 
     <string name="ignore_post_confirm_title">你確定要遮蔽此串嗎？</string>
     <string name="ignore_post_confirm_message">今後你只能通過輸入此串串號進入</string>
+    <string name="ignore_post_confirm_message_strict">今後除非你通過設定取消遮蔽所有串，否則將無法再次訪問</string>
+
+    <string name="ignore_post_message">此串已被你遮蔽</string>
 
     <string name="comment_copied_clipboard">評論文字已複製到剪貼簿</string>
 
@@ -278,6 +281,9 @@
     <string name="main_fix_image_urls">修正圖片連結</string>
     <string name="main_fix_image_urls_summary_on">使用預設圖片連結</string>
     <string name="main_fix_image_urls_summary_off">通過 API 獲取圖片連結。若圖片載入失敗，請啟用該項。</string>
+    <string name="main_strict_ignore_post_mode">嚴格遮蔽模式</string>
+    <string name="main_strict_ignore_post_mode_summary_on">你將無法訪問被遮蔽的串</string>
+    <string name="main_strict_ignore_post_mode_summary_off">你仍可通過輸入串號的方式訪問被遮蔽的串</string>
     <string name="main_restore_ignored_post">恢復所有已遮蔽的串</string>
     <string name="main_restore_ignored_post_summary">你之前所遮蔽的串將會重新出現</string>
     <string name="main_restore_ignored_post_successfully">已恢復所有被遮蔽的串</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="type_send_watermark">Watermark</string>
 
     <string name="doodle">Doodle</string>
+    <string name="doodle_reset_color">Reset</string>
     <string name="save_doodle">Save doodle?</string>
     <string name="cant_create_image_file">Can\'t create image file</string>
     <string name="saving">Saving…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -105,6 +105,9 @@
 
     <string name="ignore_post_confirm_title">Are you sure want to ignore this post?</string>
     <string name="ignore_post_confirm_message">After ignored, you can access it from enter post id only.</string>
+    <string name="ignore_post_confirm_message_strict">After ignored, you can\'t access these posts unless you restored all ignored posts.</string>
+
+    <string name="ignore_post_message">This post has been ignored</string>
 
     <string name="comment_copied_clipboard">Copied to clipboard</string>
 
@@ -285,6 +288,9 @@
     <string name="main_fix_image_urls">Fix image URLs</string>
     <string name="main_fix_image_urls_summary_on">Use default image URLs</string>
     <string name="main_fix_image_urls_summary_off">Get image URLs from the API. Enable it if loading images failed</string>
+    <string name="main_strict_ignore_post_mode">Strict ignore post mode</string>
+    <string name="main_strict_ignore_post_mode_summary_on">You can\'t access ignored posts anymore</string>
+    <string name="main_strict_ignore_post_mode_summary_off">You still can access ignored posts using go to post id</string>
     <string name="main_restore_ignored_post">Restore all ignored posts</string>
     <string name="main_restore_ignored_post_summary">The posts you ignored will redisplayed</string>
     <string name="main_restore_ignored_post_successfully">Restoring successful</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">Haha</string>
     <string name="go_to_post">Go to thread</string>
     <string name="keyword_empty">Keyword is empty</string>
+    <string name="invalid_post_id">Thread id is not valid</string>
     <string name="not_found">Nobody here but us chickens</string>
     <string name="search_title">Search - %s</string>
 

--- a/app/src/main/res/xml/config_settings.xml
+++ b/app/src/main/res/xml/config_settings.xml
@@ -83,6 +83,15 @@
         android:defaultValue="0"
         android:widgetLayout="@layout/preference_widget_icon_list"/>
 
+    <com.hippo.preference.FixedSwitchPreference
+        style="?android:attr/preferenceStyle"
+        android:key="strict_ignore_post_mode"
+        android:title="@string/main_strict_ignore_post_mode"
+        app:summaryOn="@string/main_strict_ignore_post_mode_summary_on"
+        app:summaryOff="@string/main_strict_ignore_post_mode_summary_off"
+        android:defaultValue="false"
+        android:widgetLayout="@layout/preference_widget_fixed_switch"/>
+
     <Preference
         android:key="restore_ignored_posts"
         android:title="@string/main_restore_ignored_post"


### PR DESCRIPTION
附加功能：
- 可在主界面查詢A島公告
- 可輸入頁碼跳轉頁面，而無需拖動滾動條，對頁數較多的串十分有用（比如接龍串、集中串等）
- 修復搜索界面中人工跳轉串的功能，若搜索內容非數字將阻止跳轉串以免錯誤
- 塗鴉時可重設筆畫顏色
- 更嚴格的屏蔽串功能，串被屏蔽後將無法再次訪問，默認禁用可手動啓用

以上功能之變動來自自己的[備胎島復刻](https://github.com/WUGqnwvMQPzl/tnmb/commits/master)~~，備胎島餅乾被碎了也就沒有繼續弄的必要了，索性直接帶到上游~~

改動比較多，可能需要進一步測試