### PR TITLE
Show forum notice everytime

### DIFF
--- a/app/src/main/java/com/hippo/app/CheckBoxDialogBuilder.java
+++ b/app/src/main/java/com/hippo/app/CheckBoxDialogBuilder.java
@@ -28,18 +28,25 @@ import com.hippo.nimingban.R;
 
 public class CheckBoxDialogBuilder extends AlertDialog.Builder {
 
+    private final boolean mShowCheckbox;
     private final CheckBox mCheckBox;
 
     @SuppressLint("InflateParams")
-    public CheckBoxDialogBuilder(Context context, CharSequence message, String checkText, boolean checked) {
+    public CheckBoxDialogBuilder(Context context, CharSequence message, String checkText, boolean showCheckbox, boolean checked) {
         super(context);
         View view = LayoutInflater.from(context).inflate(R.layout.dialog_checkbox_builder, null);
         setView(view);
         TextView messageView = (TextView) view.findViewById(R.id.message);
+        mShowCheckbox = showCheckbox;
         mCheckBox = (CheckBox) view.findViewById(R.id.checkbox);
         messageView.setText(message);
         mCheckBox.setText(checkText);
         mCheckBox.setChecked(checked);
+        if (!showCheckbox) mCheckBox.setVisibility(View.GONE);
+    }
+
+    public boolean isShowCheckbox() {
+        return mShowCheckbox;
     }
 
     public boolean isChecked() {

--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -143,6 +143,7 @@ public final class ListActivity extends AbsActivity
     private ActionBarDrawerToggle mDrawerToggle;
 
     private MenuItem mRule;
+    private MenuItem mNotice;
     private MenuItem mCreatePost;
     private MenuItem mSortForumsMenu;
 
@@ -230,6 +231,7 @@ public final class ListActivity extends AbsActivity
                 }
                 if (mRightDrawer == view) {
                     setMenuItemVisible(mRule, true);
+                    setMenuItemVisible(mNotice, true);
                     setMenuItemVisible(mCreatePost, true);
                     setMenuItemVisible(mSortForumsMenu, false);
                 }
@@ -242,6 +244,7 @@ public final class ListActivity extends AbsActivity
                 }
                 if (mRightDrawer == view) {
                     setMenuItemVisible(mRule, false);
+                    setMenuItemVisible(mNotice, false);
                     setMenuItemVisible(mCreatePost, false);
                     setMenuItemVisible(mSortForumsMenu, true);
                 }
@@ -638,7 +641,11 @@ public final class ListActivity extends AbsActivity
         mNMBClient.execute(request);
 
         // Get Notice
-        request = new NMBRequest();
+        getNotice(false);
+    }
+
+    private void getNotice(final boolean forceDisplay) {
+        NMBRequest request = new NMBRequest();
         mNoticeRequest = request;
         request.setSite(ACSite.getInstance());
         request.setMethod(NMBClient.METHOD_NOTICE);
@@ -655,17 +662,17 @@ public final class ListActivity extends AbsActivity
                 }
                 long oldDate = Settings.getNoticeDate();
                 final long newDate = result.date;
-                if (newDate <= oldDate) {
+                if (newDate <= oldDate && !forceDisplay) {
                     return;
                 }
 
                 final CheckBoxDialogBuilder builder = new CheckBoxDialogBuilder(
-                        ListActivity.this, Html.fromHtml(result.content), getString(R.string.get_it), false);
+                        ListActivity.this, Html.fromHtml(result.content), getString(R.string.get_it), !forceDisplay, false);
                 Dialog dialog = builder.setTitle(R.string.notice).setOnDismissListener(
                         new DialogInterface.OnDismissListener() {
                             @Override
                             public void onDismiss(DialogInterface dialog) {
-                                if (builder.isChecked()) {
+                                if (builder.isShowCheckbox() && builder.isChecked()) {
                                     Settings.putNoticeDate(newDate);
                                 }
                             }
@@ -796,15 +803,18 @@ public final class ListActivity extends AbsActivity
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.activity_list, menu);
         mRule = menu.findItem(R.id.action_rule);
+        mNotice = menu.findItem(R.id.action_notice);
         mCreatePost = menu.findItem(R.id.action_create_post);
         mSortForumsMenu = menu.findItem(R.id.action_sort_forums);
 
         if (mDrawerLayout.isDrawerOpen(Gravity.RIGHT)) {
             mRule.setVisible(false);
+            mNotice.setVisible(false);
             mCreatePost.setVisible(false);
             mSortForumsMenu.setVisible(true);
         } else {
             mRule.setVisible(true);
+            mNotice.setVisible(true);
             mCreatePost.setVisible(true);
             mSortForumsMenu.setVisible(false);
         }
@@ -874,6 +884,10 @@ public final class ListActivity extends AbsActivity
                     tv.setMovementMethod(new LinkMovementMethod2(ListActivity.this));
                     new AlertDialog.Builder(this).setTitle(R.string.rule).setView(view).show();
                 }
+                return true;
+            case R.id.action_notice:
+                if (mCurrentForum != null)
+                    getNotice(true);
                 return true;
             case R.id.action_create_post:
                 if (mCurrentForum != null) {

--- a/app/src/main/res/menu/activity_list.xml
+++ b/app/src/main/res/menu/activity_list.xml
@@ -32,6 +32,11 @@
         app:showAsAction="never"/>
 
     <item
+        android:id="@+id/action_notice"
+        android:title="@string/notice"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_sort_forums"
         android:title="@string/sort_forums"
         android:icon="@drawable/v_sort_dark_x24"


### PR DESCRIPTION
拆分自 PR #100 

經常可以看到有一些人在島上問里島的地址，而里島的地址經常出現在公告上

但是很多人看到公告之後通常都是點一下“我知道了”然後退出，等到下一次需要再次查閱公告時只能等到下一個新公告發佈自動彈出才可

於是在主界面上加入了公告的入口（在工具欄菜單中），即使選擇了下次不會彈出，也可以隨時查閱公告

_順便一提，經常有很多人拿紫島的彩蛋去愚弄他人作樂（比如前面提到的，有人經常問里島的入口，很多人就會誘導對方觸發紫島的彩蛋），河馬你有什麼頭緒嗎？_