### PR TITLE
Prevent going to thread with invalid post id

### DIFF
--- a/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
+++ b/app/src/main/java/com/hippo/nimingban/ui/ListActivity.java
@@ -1007,6 +1007,11 @@ public final class ListActivity extends AbsActivity
                 startActivity(intent);
                 mDialog.dismiss();
             } else if (mNeutral == v) {
+                if (!TextUtils.isDigitsOnly(keyword)) {
+                    Toast.makeText(ListActivity.this, R.string.invalid_post_id, Toast.LENGTH_SHORT).show();
+                    return;
+                }
+
                 Intent intent = new Intent(ListActivity.this, PostActivity.class);
                 intent.setAction(PostActivity.ACTION_SITE_REPLY_ID);
                 intent.putExtra(PostActivity.KEY_SITE, ACSite.getInstance().getId());

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">关键字为空</string>
+    <string name="invalid_post_id">不是有效的串号</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜索 - %s</string>
 

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">關鍵字為空</string>
+    <string name="invalid_post_id">不是有效的串號</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜索 - %s</string>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">哈哈</string>
     <string name="go_to_post">去串</string>
     <string name="keyword_empty">關鍵字為空</string>
+    <string name="invalid_post_id">不是有效的串號</string>
     <string name="not_found">啥都找不到</string>
     <string name="search_title">搜尋 - %s</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,6 +72,7 @@
     <string name="lucky">Haha</string>
     <string name="go_to_post">Go to thread</string>
     <string name="keyword_empty">Keyword is empty</string>
+    <string name="invalid_post_id">Thread id is not valid</string>
     <string name="not_found">Nobody here but us chickens</string>
     <string name="search_title">Search - %s</string>
 


### PR DESCRIPTION
拆分自 PR #100 

在使用搜索功能手動輸入串號進串時，若包含非數字會自動阻止

只是簡單地修復了一個設計缺陷，即使不會造成應用崩潰，注重細節還是好事